### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,9 @@ name: Python Package using Conda
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mocimoda/Victoria789/security/code-scanning/1](https://github.com/mocimoda/Victoria789/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require write access to the repository, we can set the permissions to `contents: read`. This ensures that the workflow has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This change does not affect the functionality of the workflow but improves its security posture.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
